### PR TITLE
Strengthen interpolation coverage in cross section tests

### DIFF
--- a/test/string_parse_elastic_test.jl
+++ b/test/string_parse_elastic_test.jl
@@ -13,9 +13,31 @@ UPDATED: 2022-09-02 11:05:07
 
 cs = parse_string(string)
 
-@test cs.type.projectile == "e" 
-@test cs.type.target == "CH4" 
+@test cs.type.projectile == "e"
+@test cs.type.target == "CH4"
 @test cs.type.mass_ratio == 3.424e-5
 @test cs.comment == ""
 @test cs.updated == DateTime("2022-09-02T11:05:07")
 @test cs.cross_section(1e3) == 3.14e-21
+@test collect(Interpolations.knots(cs.cross_section)) == [0.0, 1.0, 1000.0]
+
+unsorted_string = """ELASTIC
+He
+  2.500000e-5 / mass ratio
+UPDATED: 2020-01-01 00:00:00
+------------------------------------------------------------
+ 2.0000e+0      2.0000e-20
+ 0.0000e+0      0.0000e+0
+ 1.0000e+0      1.0000e-20
+------------------------------------------------------------
+"""
+
+unsorted_cs = parse_string(unsorted_string)
+
+@test unsorted_cs.type.projectile == "e"
+@test unsorted_cs.type.target == "He"
+@test unsorted_cs.type.mass_ratio == 2.5e-5
+@test unsorted_cs.updated == DateTime("2020-01-01T00:00:00")
+@test unsorted_cs.cross_section(0.5) ≈ 5.0e-21 atol=eps()
+@test unsorted_cs.cross_section(1.5) ≈ 1.5e-20 atol=eps()
+@test collect(Interpolations.knots(unsorted_cs.cross_section)) == [0.0, 1.0, 2.0]

--- a/test/string_parse_excitation_test.jl
+++ b/test/string_parse_excitation_test.jl
@@ -18,10 +18,34 @@ UPDATED: 2010-06-23 11:41:34
 
 cs = parse_string(string)
 
-@test cs.type.projectile == "e" 
-@test cs.type.target == "Ar" 
-@test cs.type.excited_state == "Ar*(11.5eV)" 
-@test cs.type.threshold_energy == 1.15e1 
+@test cs.type.projectile == "e"
+@test cs.type.target == "Ar"
+@test cs.type.excited_state == "Ar*(11.5eV)"
+@test cs.type.threshold_energy == 1.15e1
 @test cs.comment == "All excitation is grouped into this one level."
 @test cs.updated == DateTime("2010-06-23T11:41:34")
 @test cs.cross_section(1e3) == 1.77e-21
+@test collect(Interpolations.knots(cs.cross_section)) == [1000.0, 1500.0, 2000.0, 3000.0, 5000.0, 7000.0, 10000.0]
+
+bidirectional_string = """EXCITATION
+N2(v=0) <-> N2(v=1)
+  2.500000e+0  3.500000e-1 / threshold energy and statistical weight ratio
+UPDATED: 2021-01-01 12:34:56
+------------------------------------------------------------
+ 0.0000e+0      0.0000e+0
+ 2.5000e+0      2.5000e-21
+ 5.0000e+0      5.0000e-21
+------------------------------------------------------------
+"""
+
+bidirectional_cs = parse_string(bidirectional_string)
+
+@test bidirectional_cs.type.projectile == "e"
+@test bidirectional_cs.type.target == "N2(v=0)"
+@test bidirectional_cs.type.excited_state == "N2(v=1)"
+@test bidirectional_cs.type.threshold_energy == 2.5
+@test bidirectional_cs.type.stat_weight_ratio == 3.5e-1
+@test bidirectional_cs.comment == ""
+@test bidirectional_cs.updated == DateTime("2021-01-01T12:34:56")
+@test bidirectional_cs.cross_section(3.75) ≈ 3.75e-21 atol=eps()
+@test collect(Interpolations.knots(bidirectional_cs.cross_section)) == [0.0, 2.5, 5.0]


### PR DESCRIPTION
## Summary
- assert the interpolation grids for elastic cross sections, including unsorted inputs, are sorted as expected
- verify excitation cross section knots for both single-direction and bidirectional transitions

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'`


------
https://chatgpt.com/codex/tasks/task_e_68cf5cb6a81c832f93259437a2e9962d